### PR TITLE
normalized line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@ root = true
 
 [*]
 charset = utf-8
-end_of_line = crlf
+end_of_line = lf
 max_line_length = 360
 indent_size = 4
 indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,3 @@
 # Auto detect text files and perform LF normalization
 * text=auto
-
-# Datagen outputs LF, so we respect that
-/src/main/generated/* text eol=lf
+* eol=lf


### PR DESCRIPTION
everything should use lf, previously the git and editor configs conflicted as to whether crlf or lf should be used