### PR TITLE
Fix tag use in cake recipe

### DIFF
--- a/src/main/resources/data/minecraft/recipe/cake.json
+++ b/src/main/resources/data/minecraft/recipe/cake.json
@@ -9,7 +9,7 @@
   ],
   "key": {
     "A": {
-      "tag": "#c:buckets/milk"
+      "tag": "c:buckets/milk"
     },
     "B": {
       "item": "minecraft:sugar"
@@ -18,7 +18,7 @@
       "item": "minecraft:wheat"
     },
     "E": {
-      "tag": "#c:eggs"
+      "tag": "c:eggs"
     }
   },
   "result": {


### PR DESCRIPTION
Needs no # on the tags, tested this by overwriting the recipe with a KubeJS datapack and removing the # made the recipe show up (and KubeJS stop complaining).