### PR TITLE
Fix i-frames in Azure Dike. Fixes #147

### DIFF
--- a/src/main/java/earth/terrarium/pastel/events/PastelDamageEvents.java
+++ b/src/main/java/earth/terrarium/pastel/events/PastelDamageEvents.java
@@ -57,7 +57,6 @@ public class PastelDamageEvents {
         NeoForge.EVENT_BUS.addListener(PastelDamageEvents::handlePiercing);
         NeoForge.EVENT_BUS.addListener(PastelDamageEvents::vulnerability);
         NeoForge.EVENT_BUS.addListener(PastelDamageEvents::handlePuffCirclet);
-        NeoForge.EVENT_BUS.addListener(EventPriority.LOWEST, PastelDamageEvents::handleDike);
         NeoForge.EVENT_BUS.addListener(EventPriority.LOWEST, PastelDamageEvents::applyKillBonuses);
     }
 
@@ -163,19 +162,6 @@ public class PastelDamageEvents {
         }
 
         event.setCanceled(true); // No further processing required for this
-    }
-
-    // Holy lesbians
-    private static void handleDike(LivingIncomingDamageEvent event) {
-        if (event.getSource()
-                 .is(PastelDamageTypeTags.BYPASSES_DIKE))
-            return;
-
-        var target = event.getEntity();
-        var container = event.getContainer();
-
-
-        container.setNewDamage(AzureDikeProvider.absorbDamage(target, container.getNewDamage()));
     }
 
     private static final Set<LivingEntity> RECURSIVE_TARGETS = new HashSet<>();

--- a/src/main/java/earth/terrarium/pastel/mixin/LivingEntityMixin.java
+++ b/src/main/java/earth/terrarium/pastel/mixin/LivingEntityMixin.java
@@ -11,6 +11,7 @@ import earth.terrarium.pastel.api.entity.TouchingWaterAware;
 import earth.terrarium.pastel.api.item.SlotReservingItem;
 import earth.terrarium.pastel.attachments.data.EverpromiseRibbonData;
 import earth.terrarium.pastel.attachments.data.MiscPlayerData;
+import earth.terrarium.pastel.attachments.data.azure_dike.AzureDikeProvider;
 import earth.terrarium.pastel.blocks.memory.MemoryItem;
 import earth.terrarium.pastel.components.PairedFoodComponent;
 import earth.terrarium.pastel.helpers.enchantments.Ench;
@@ -19,12 +20,7 @@ import earth.terrarium.pastel.injectors.MobEffectInstanceInjector;
 import earth.terrarium.pastel.items.tools.ParryingSwordItem;
 import earth.terrarium.pastel.items.trinkets.PastelTrinketItem;
 import earth.terrarium.pastel.items.trinkets.RingOfAerialGraceItem;
-import earth.terrarium.pastel.registries.PastelDataComponentTypes;
-import earth.terrarium.pastel.registries.PastelEnchantments;
-import earth.terrarium.pastel.registries.PastelEntityAttributes;
-import earth.terrarium.pastel.registries.PastelItems;
-import earth.terrarium.pastel.registries.PastelMobEffects;
-import earth.terrarium.pastel.registries.PastelSounds;
+import earth.terrarium.pastel.registries.*;
 import earth.terrarium.pastel.status_effects.EffectProlongingStatusEffect;
 import earth.terrarium.pastel.status_effects.SleepStatusEffect;
 import net.minecraft.core.Holder;
@@ -44,6 +40,7 @@ import net.minecraft.world.food.FoodProperties;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
+import net.neoforged.neoforge.common.damagesource.DamageContainer;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -55,6 +52,8 @@ import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Stack;
 
 @Mixin(LivingEntity.class)
 public abstract class LivingEntityMixin {
@@ -96,6 +95,9 @@ public abstract class LivingEntityMixin {
 
     @Shadow
     public boolean dead;
+
+    @Shadow
+    protected Stack<DamageContainer> damageContainers;
 
     @Inject(method = "createLivingAttributes", require = 1, allow = 1, at = @At("RETURN"))
     private static void addAttributes(final CallbackInfoReturnable<AttributeSupplier.Builder> cir) {
@@ -342,4 +344,15 @@ public abstract class LivingEntityMixin {
                                         : livingEntity.isInWaterRainOrBubble();
     }
 
+    @WrapOperation(at = @At(value = "INVOKE", target = "net/minecraft/world/entity/LivingEntity.actuallyHurt(Lnet/minecraft/world/damagesource/DamageSource;F)V"), method = "hurt")
+    private void applyDike(LivingEntity instance, DamageSource source, float amount, Operation<Void> original) {
+        if (source.is(PastelDamageTypeTags.BYPASSES_DIKE)) {
+            original.call(instance, source, amount);
+            return;
+        }
+        var container = this.damageContainers.peek();
+        var passedDamage = AzureDikeProvider.absorbDamage(instance, container.getNewDamage());
+        container.setNewDamage(passedDamage);
+        instance.actuallyHurt(source, passedDamage);
+    }
 }


### PR DESCRIPTION
~LivingIncomingDamageEvent is called very early in the pipeline, before damage reductions and i-frames are calculated, LivingDamageEvent.Pre seems to fit here better~

LivingDamageEvent.Pre is called after effect & enchantment damage reduction, which also isn't what we want, so I ended up using an approach from Spectrum adapting it to the NeoForge system