### PR TITLE
Fix structure sets 

### DIFF
--- a/src/main/resources/data/pastel/worldgen/structure_set/city_below.json
+++ b/src/main/resources/data/pastel/worldgen/structure_set/city_below.json
@@ -11,10 +11,10 @@
     "frequency": 0.9,
     "spread_type": "triangular",
     "spacing": 24,
-    "separation": 16
-  },
-  "exclusion_zone": {
-    "chunk_count": 16,
-    "other_set": "pastel:undergrowth_manor"
+    "separation": 16,
+    "exclusion_zone": {
+      "chunk_count": 16,
+      "other_set": "pastel:undergrowth_manor"
+    }
   }
 }

--- a/src/main/resources/data/pastel/worldgen/structure_set/lizard_den.json
+++ b/src/main/resources/data/pastel/worldgen/structure_set/lizard_den.json
@@ -11,7 +11,7 @@
     {
       "structure": "pastel:lizard_den/dripstone",
       "weight": 1
-    },
+    },	
     {
       "structure": "pastel:lizard_den/basal_marble",
       "weight": 1
@@ -20,7 +20,7 @@
   "placement": {
     "type": "minecraft:random_spread",
     "salt": 893368,
-    "exclusion zone": {
+    "exclusion_zone": {
       "other_set": "pastel:city_below",
       "chunk_count": 1
     },

--- a/src/main/resources/data/pastel/worldgen/structure_set/undergrowth_manor.json
+++ b/src/main/resources/data/pastel/worldgen/structure_set/undergrowth_manor.json
@@ -11,10 +11,10 @@
     "spread_type": "triangular",
     "frequency": 0.9,
     "spacing": 80,
-    "separation": 60
-  },
-  "exclusion_zone": {
-    "chunk_count": 16,
-    "other_set": "pastel:city_below"
+    "separation": 60,
+    "exclusion_zone": {
+      "chunk_count": 16,
+      "other_set": "pastel:city_below"
+    }
   }
 }


### PR DESCRIPTION
Fix the formatting on the city below and undergrowth manor structures so that they *actually* exclude each other and add an _ to the lizard dens so they they avoid cities
Fixes #192 