### PR TITLE
Optimize compacting chest

### DIFF
--- a/src/main/java/earth/terrarium/pastel/blocks/chests/CompactingChestBlockEntity.java
+++ b/src/main/java/earth/terrarium/pastel/blocks/chests/CompactingChestBlockEntity.java
@@ -3,7 +3,7 @@ package earth.terrarium.pastel.blocks.chests;
 import earth.terrarium.pastel.api.item.ItemReference;
 import earth.terrarium.pastel.api.item.ItemStorage;
 import earth.terrarium.pastel.helpers.interaction.InventoryHelper;
-import earth.terrarium.pastel.inventories.AutoCraftingMode;
+import earth.terrarium.pastel.inventories.CompactionCraftingMode;
 import earth.terrarium.pastel.inventories.CompactingChestScreenHandler;
 import earth.terrarium.pastel.networking.s2c_payloads.CompactingChestStatusUpdatePayload;
 import earth.terrarium.pastel.registries.PastelBlockEntities;
@@ -28,7 +28,6 @@ import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.ContainerData;
-import net.minecraft.world.item.crafting.CraftingInput;
 import net.minecraft.world.item.crafting.CraftingRecipe;
 import net.minecraft.world.item.crafting.RecipeHolder;
 import net.minecraft.world.item.crafting.RecipeType;
@@ -45,15 +44,14 @@ public class CompactingChestBlockEntity extends PastelChestBlockEntity {
     private static final FlowAnimator.Factory<CompactingChestBlockEntity> FACTORY;
 
     @NotNull
-    private AutoCraftingMode mode = AutoCraftingMode.X3;
+    private CompactionCraftingMode mode = CompactionCraftingMode.X3;
     @NotNull
-    private Optional<RecipeHolder<CraftingRecipe>> cachedRecipe = Optional.empty();
+    private Optional<CompactionRecipe> activeRecipe = Optional.empty();
     private boolean isOpen;
     public long craftingTimeStamp;
 
     protected FlowAnimator animator;
     protected FlowData<Float> _piston = FlowData.NULL(), _driver = FlowData.NULL(), _cap = FlowData.NULL();
-
 
     private final ContainerData propertyDelegate = new ContainerData() {
         @Override
@@ -64,7 +62,7 @@ public class CompactingChestBlockEntity extends PastelChestBlockEntity {
 
         @Override
         public void set(int index, int value) {
-            if (index == 0) mode = AutoCraftingMode.values()[value];
+            if (index == 0) mode = CompactionCraftingMode.values()[value];
         }
 
         @Override
@@ -102,26 +100,23 @@ public class CompactingChestBlockEntity extends PastelChestBlockEntity {
     }
 
     private void process() {
-        var available = InventoryHelper.getAvailableItems(inventory);
-
-        if (cachedRecipe.isEmpty()) {
-            findRecipe(available);
+        if (activeRecipe.isEmpty()) {
+            activeRecipe = findRecipe(mode, InventoryHelper.getAvailableItems(inventory));
             return;
         }
 
-        var recipe = cachedRecipe.get();
-        var ref = AutoCraftingMode.getCache(mode)
-                                  .getOrDefault(recipe.id(), ItemReference.empty());
+        var recipe = activeRecipe.get();
+        var ref = recipe.inputRef();
 
         if (ref.isEmpty())
             return;
 
-        if (!hasEnough(ref, available)) {
-            cachedRecipe = Optional.empty();
+        if (!InventoryHelper.isItemCountInInventory(inventory, ref, mode.getSize())) {
+            activeRecipe = Optional.empty();
             return;
         }
 
-        var result = recipe.value()
+        var result = recipe.recipe().value()
                            .getResultItem(level.registryAccess())
                            .copy();
 
@@ -141,48 +136,34 @@ public class CompactingChestBlockEntity extends PastelChestBlockEntity {
         }
     }
 
-    private boolean hasEnough(ItemReference ref, List<ItemStorage> available) {
-        if (available.isEmpty())
-            return false;
-
-        for (ItemStorage itemStorage : available) {
-            if (!itemStorage.getReference()
-                            .equals(ref))
-                continue;
-
-            if (itemStorage.getCount() >= mode.getSize())
-                return true;
-        }
-        return false;
-    }
-
-    private void findRecipe(List<ItemStorage> available) {
-        CraftingInput input = null;
-        ItemReference target = null;
-
+    private Optional<CompactionRecipe> findRecipe(CompactionCraftingMode mode, List<ItemStorage> available) {
+        var compactionCache = mode.getCache();
         for (ItemStorage storage : available) {
             if (storage.getCount() >= mode.getSize()) {
-                input = mode.createRecipeInput(storage.stack(1))
-                            .input();
-                target = storage.getReference();
+                var inputStack = mode.createRecipeInput(storage.stack(1))
+                        .input();
+                var inputRef = storage.getReference();
 
-                cachedRecipe = level.getRecipeManager()
-                                    .getRecipeFor(RecipeType.CRAFTING, input, level);
-                if (cachedRecipe.isPresent())
-                    break;
+                var cacheTry = compactionCache.get(inputRef);
+                if (cacheTry.isPresent()) {
+                    var cacheHit = cacheTry.get();
+                    // the cache hit so there's no need to go to the global recipe manager
+                    // if the recipe is not present, this item is not compactable in this mode
+                    if (cacheHit.isPresent())
+                        return cacheHit.map(r -> new CompactionRecipe(inputRef, r));
+                    else
+                        continue;
+                }
+
+                var recipe = level.getRecipeManager()
+                                  .getRecipeFor(RecipeType.CRAFTING, inputStack, level);
+                
+                compactionCache.put(inputRef, recipe);
+                if (recipe.isPresent())
+                    return recipe.map(r -> new CompactionRecipe(inputRef, r));
             }
         }
-
-        if (input == null)
-            return;
-
-        ItemReference finalTarget = target;
-        cachedRecipe.ifPresent(r -> {
-            var recipes = AutoCraftingMode.getCache(mode);
-            recipes.putIfAbsent(r.id(), finalTarget);
-            craftingTimeStamp = level.getGameTime();
-            CompactingChestStatusUpdatePayload.sendCompactingChestStatusUpdate(this);
-        });
+        return Optional.empty();
     }
 
     public void produceRunningEffects() {
@@ -212,7 +193,11 @@ public class CompactingChestBlockEntity extends PastelChestBlockEntity {
         super.loadAdditional(tag, registryLookup);
         if (tag.contains("AutoCraftingMode", Tag.TAG_ANY_NUMERIC)) {
             int autoCraftingModeInt = tag.getInt("AutoCraftingMode");
-            this.mode = AutoCraftingMode.values()[autoCraftingModeInt];
+            var mode = CompactionCraftingMode.values()[autoCraftingModeInt];
+            if (this.mode != mode) {
+                this.mode = mode;
+                this.activeRecipe = Optional.empty();
+            }
         }
     }
 
@@ -240,12 +225,12 @@ public class CompactingChestBlockEntity extends PastelChestBlockEntity {
         return PastelSounds.COMPACTING_CHEST_CLOSE;
     }
 
-    public void applySettings(AutoCraftingMode mode) {
+    public void applySettings(CompactionCraftingMode mode) {
         if (this.mode == mode)
             return;
 
         this.mode = mode;
-        this.cachedRecipe = Optional.empty();
+        this.activeRecipe = Optional.empty();
         setChanged();
     }
 
@@ -295,4 +280,6 @@ public class CompactingChestBlockEntity extends PastelChestBlockEntity {
 
         FACTORY = builder.build();
     }
+
+    private record CompactionRecipe(ItemReference inputRef, RecipeHolder<CraftingRecipe> recipe) {}
 }

--- a/src/main/java/earth/terrarium/pastel/events/PastelMiscEvents.java
+++ b/src/main/java/earth/terrarium/pastel/events/PastelMiscEvents.java
@@ -12,7 +12,7 @@ import earth.terrarium.pastel.entity.spawners.ShootingStarSpawner;
 import earth.terrarium.pastel.helpers.Support;
 import earth.terrarium.pastel.helpers.enchantments.Ench;
 import earth.terrarium.pastel.helpers.interaction.TimeHelper;
-import earth.terrarium.pastel.inventories.AutoCraftingMode;
+import earth.terrarium.pastel.inventories.CompactionCraftingMode;
 import earth.terrarium.pastel.items.magic_items.ExchangeStaffItem;
 import earth.terrarium.pastel.items.tools.GlassCrestCrossbowItem;
 import earth.terrarium.pastel.items.tools.TuningStampItem;
@@ -176,7 +176,7 @@ public class PastelMiscEvents {
                 if (!FMLEnvironment.dist.isDedicatedServer())
                     PastelSided.clearToastManager();
 
-                AutoCraftingMode.clearCache();
+                CompactionCraftingMode.clearCache();
                 PastelCommon.CACHED_ITEM_TAG_MAP.clear();
 
                 if (PastelCommon.getSidedServer() != null) {

--- a/src/main/java/earth/terrarium/pastel/inventories/CompactingChestScreenHandler.java
+++ b/src/main/java/earth/terrarium/pastel/inventories/CompactingChestScreenHandler.java
@@ -123,8 +123,8 @@ public class CompactingChestScreenHandler extends AbstractContainerMenu {
         return blockEntity;
     }
 
-    public AutoCraftingMode getCraftingMode() {
-        return AutoCraftingMode.values()[propertyDelegate.get(0)];
+    public CompactionCraftingMode getCraftingMode() {
+        return CompactionCraftingMode.values()[propertyDelegate.get(0)];
     }
 
 }

--- a/src/main/java/earth/terrarium/pastel/inventories/CompactionCraftingMode.java
+++ b/src/main/java/earth/terrarium/pastel/inventories/CompactionCraftingMode.java
@@ -1,28 +1,31 @@
 package earth.terrarium.pastel.inventories;
 
 import earth.terrarium.pastel.api.item.ItemReference;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.CraftingInput;
+import net.minecraft.world.item.crafting.CraftingRecipe;
+import net.minecraft.world.item.crafting.RecipeHolder;
 
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
-public enum AutoCraftingMode {
+
+public enum CompactionCraftingMode {
     X1(1, 1),
     X2(2, 2),
     X3(3, 3);
 
-    private static final Map<AutoCraftingMode, Map<ResourceLocation, ItemReference>> CACHE = new EnumMap<>(
-        AutoCraftingMode.class);
+    private static final Map<CompactionCraftingMode, CompactionRecipeCache> CACHE = new EnumMap<>(
+        CompactionCraftingMode.class);
 
     private final int width;
     private final int height;
 
-    AutoCraftingMode(int width, int height) {
+    CompactionCraftingMode(int width, int height) {
         this.width = width;
         this.height = height;
     }
@@ -39,8 +42,8 @@ public enum AutoCraftingMode {
         return width * height;
     }
 
-    public AutoCraftingMode next() {
-        return AutoCraftingMode.values()[(this.ordinal() + 1) % values().length];
+    public CompactionCraftingMode next() {
+        return CompactionCraftingMode.values()[(this.ordinal() + 1) % values().length];
     }
 
     public CraftingInput.Positioned createRecipeInput(ItemStack variant) {
@@ -52,12 +55,23 @@ public enum AutoCraftingMode {
         return CraftingInput.ofPositioned(width, height, inputs);
     }
 
-    public static Map<ResourceLocation, ItemReference> getCache(AutoCraftingMode mode) {
-        return CACHE.computeIfAbsent(mode, m -> new HashMap<>());
+    public CompactionRecipeCache getCache() {
+        return CACHE.computeIfAbsent(this, m -> new CompactionRecipeCache());
     }
 
     public static void clearCache() {
         CACHE.clear();
+    }
+    public static class CompactionRecipeCache {
+        private final Map<ItemReference, Optional<RecipeHolder<CraftingRecipe>>> cache = new HashMap<>();
+
+        public Optional<Optional<RecipeHolder<CraftingRecipe>>> get(ItemReference input) {
+            return Optional.ofNullable(cache.get(input));
+        }
+
+        public void put(ItemReference input, Optional<RecipeHolder<CraftingRecipe>> recipe) {
+            cache.put(input, recipe);
+        }
     }
 }
 

--- a/src/main/java/earth/terrarium/pastel/networking/c2s_payloads/ChangeCompactingChestSettingsPayload.java
+++ b/src/main/java/earth/terrarium/pastel/networking/c2s_payloads/ChangeCompactingChestSettingsPayload.java
@@ -2,7 +2,7 @@ package earth.terrarium.pastel.networking.c2s_payloads;
 
 import earth.terrarium.pastel.blocks.chests.CompactingChestBlockEntity;
 import earth.terrarium.pastel.helpers.data.PacketCodecHelper;
-import earth.terrarium.pastel.inventories.AutoCraftingMode;
+import earth.terrarium.pastel.inventories.CompactionCraftingMode;
 import earth.terrarium.pastel.inventories.CompactingChestScreenHandler;
 import earth.terrarium.pastel.networking.PastelC2SPackets;
 import net.minecraft.network.FriendlyByteBuf;
@@ -11,13 +11,13 @@ import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.neoforged.neoforge.network.handling.IPayloadHandler;
 
-public record ChangeCompactingChestSettingsPayload(AutoCraftingMode mode) implements CustomPacketPayload {
+public record ChangeCompactingChestSettingsPayload(CompactionCraftingMode mode) implements CustomPacketPayload {
 
     public static final CustomPacketPayload.Type<ChangeCompactingChestSettingsPayload> ID = PastelC2SPackets.makeId(
         "change_compacting_chest_settings");
     public static final StreamCodec<FriendlyByteBuf, ChangeCompactingChestSettingsPayload> CODEC
         = StreamCodec.composite(
-        PacketCodecHelper.enumOf(AutoCraftingMode::values),
+        PacketCodecHelper.enumOf(CompactionCraftingMode::values),
         ChangeCompactingChestSettingsPayload::mode,
         ChangeCompactingChestSettingsPayload::new
     );


### PR DESCRIPTION
The current implementation of compacting chests attempts to perform a global recipe lookup for each item in the chest, every tick that it can't find something to craft, until it finds something. In particular, idle compacting chests full of a variety of items can consume an enormous amount of CPU, to the point where just 2 of them in the world were using up 7% of my friend's server's CPU.

Assuming I did everything right, I have changed exactly 0 behavior outside of possibly fixing one bug (including stuff like preserving the number of ticks it takes to switch recipes (which is two? I have no idea if that's intentional, but I left it alone)), just made the code more efficient.

# Summary of changes by file
- [src/main/java/earth/terrarium/pastel/blocks/chests/CompactingChestBlockEntity.java](https://github.com/terrarium-earth/Pastel/compare/1.21.1...yaksher:Pastel:1.21.1#diff-25210e958686ef87336482e3de597cd5ce69148fe5330ac99b49cb21047132a4): Overhauled `findRecipe`, general cleanup. (See below for details)
- [.../pastel/inventories/AutoCraftingMode.java → ...l/inventories/CompactionCraftingMode.java](https://github.com/terrarium-earth/Pastel/compare/1.21.1...yaksher:Pastel:1.21.1#diff-5f2af95c607c5fd173cea2a4a799459d409270ff348aea5d86114926599d3060): Renamed, removed the recipe -> input item cache, added an input item -> recipe cache.
- [src/main/java/earth/terrarium/pastel/events/PastelMiscEvents.java](https://github.com/terrarium-earth/Pastel/compare/1.21.1...yaksher:Pastel:1.21.1#diff-c5c487a05594c2bcdbe46663cc84f493de399d802b253afe509aebb6733e153f), [src/main/java/earth/terrarium/pastel/inventories/CompactingChestScreenHandler.java](https://github.com/terrarium-earth/Pastel/compare/1.21.1...yaksher:Pastel:1.21.1#diff-efe7a7077bfc61f7c94422592426a3f44ef70a523519563c934547396106f9b2), and [.../earth/terrarium/pastel/networking/c2s_payloads/ChangeCompactingChestSettingsPayload.java](https://github.com/terrarium-earth/Pastel/compare/1.21.1...yaksher:Pastel:1.21.1#diff-86239e6e5e8daf4ffa00e8de29fbd97b76e68a0ae4ef129a4e5ff4bbab0bca2f): Just changing `AutoCraftingMode` to `CompactionCraftingMode`.

# Details

The primary thing this commit does is create a cache which, for each compaction mode (1x1, 2x2, 3x3), maps `ItemReferences` of candidate items to the corresponding compacting recipe, if it exists, or an empty optional if it doesn't. In particular, the global `level`'s `RecipeManager` lookup chain is only invoked at most once per item per recipe reload, instead of every tick as in the existing implementation.

The existing "cache," which just served to convert from recipes to their corresponding input item, is removed in favor of just storing the input item together with the recipe.

Additionally, since I was heavily modifying the file anyway, I cleaned it up somewhat.
- `cachedRecipe` is renamed to `activeRecipe`, which I believe more accurately communicates what it actually represents (the recipe the compacting chest is currently using).
- the `findRecipe` helper is made pure (aside from modifying the cache, which isn't an observable behavior) rather than state-modifying, since I think this is somewhat more readable (and, in this case, it's not clunky since it just means one more argument and a return value, rather than some monster function of 15 variables or whatever).
- the `hasEnough` helper is entirely removed since the `InventoryHelper` class already had an `isItemCountInInventory` method which does exactly that (it is less efficient if a list of available items via `getAvailableItems` already exists, but I also changed that to only be invoked in those ticks where a new recipe is needed so the two never run in the same code path).
- `AutoCraftingMode` is renamed to `CompactionCraftingMode` since it is both only used by the compacting chest and only contains information for compacting-type recipes (1x1, 2x2, 3x3) rather than general autocrafting.
- `loadAdditional` will now immediately invalidate the active recipe if the mode changes. I believe this fixes a bug in the existing code: namely, if `loadAdditional` ever actually changed the mode in the previous code, I believe what would happen is that 
  - `cachedRecipe` would remain, so the first check (`if (cachedRecipe.isEmpty()) { findRecipe(available); return; }`) doesn't early return.
  - `AutoCraftingMode.getCache(mode).getOrDefault(recipe.id(), ItemReference.empty());` would miss, since the new mode doesn't have an entry for the old recipe in its recipe-to-ref cache.
  - The second `if (ref.isEmpty()) return;` check would fire, early returning from the function. At this point, `cachedRecipe` is still unchanged and so on the next tick, we immediately do the same thing.
  
  Correspondingly, this would cause the compacting chest to become indefinitely broken until the compacting mode is changed through the settings, which would clear the `cachedRecipe` and allow the chest to find a new recipe.

# Testing
The chests seem to function properly with respect to compacting, changing crafting modes, etc. I didn't do any super extensive functionality testing, but I did read my code pretty closely and in my brief testing I wasn't able to find any issues.[^1]

For performance[^2], 128 chests filled with 27 distinct non-compactable items with ≥9 of each cause ~`250 MSPT` of lag without the patch. With the patch, they cause too little lag to be precisely measured with my janky setup ("just run `/tick query`") but it seems to hover around `5.2-5.3 MSPT` with them and `3.8-3.9 MSPT` without them, so I guess that's roughly a total of `1.3-1.5 MSPT` total.

That is, in the worst-case scenario of chests full of 27 distinct items with ≥9 of each, this patch reduces the MSPT by a factor of 150-200 from about `~2 MSPT`[^3] per chest to a negligible `~0.012 MSPT`.

[^1]: I did find that compacting chests cause client disconnected errors when you pick block with NBT (even on a singleplayer world, which causes the game to get confused and kick you out to the server select screen lol). However, this occurs without my changes too, so I didn't bother debugging further.

[^2]: I just did the testing running on my laptop, which is an M3 Max MacBook Pro. Since Apple Silicon has pretty good single-threaded performance in general, I would assume the MSPT impact on the typical low-end servers that people run Minecraft servers on to be somewhat higher.

[^3]: Obviously this is the extreme case, but the performance cost should be linear in the number of distinct types of item of which are at least 1/4/9 in the chest (depending on whether it's set to 1x1/2x2/3x3 mode). This could easily be like 10 in natural use cases for such a chest, in which case the performance impact of the unpatched chests would sit at around `0.7 MSPT`, which is quite a lot of the server's budget for 1 chest. (And the only reason I was looking at this in the first place is that it did actually cause problems on my friend's server.)