### PR TITLE
fix(worldgen): correct exclusion_zone key in lizard_den structure set

### DIFF
--- a/src/main/resources/data/pastel/worldgen/structure_set/lizard_den.json
+++ b/src/main/resources/data/pastel/worldgen/structure_set/lizard_den.json
@@ -20,7 +20,7 @@
   "placement": {
     "type": "minecraft:random_spread",
     "salt": 893368,
-    "exclusion zone": {
+    "exclusion_zone": {
       "other_set": "pastel:city_below",
       "chunk_count": 1
     },


### PR DESCRIPTION
## Bug Summary

The `lizard_den.json` structure set uses `"exclusion zone"` (with a space) instead of `"exclusion_zone"` (with an underscore) as the placement key.

## Impact

Minecraft does not recognize the misspelled key, so the exclusion zone is **silently ignored**. This causes Lizard Dens to incorrectly generate inside City Below structures.

## Fix

Change `"exclusion zone"` → `"exclusion_zone"` in `src/main/resources/data/pastel/worldgen/structure_set/lizard_den.json` (line 23).

## Verification

- [x] Confirmed no other JSON files in the project use the same typo
- [x] Matches the standard Minecraft structure set JSON schema (`exclusion_zone` with underscore)