### PR TITLE
fix cloaked names in the guidebook

### DIFF
--- a/src/main/java/earth/terrarium/pastel/compat/modonomicon/ModonomiconCompat.java
+++ b/src/main/java/earth/terrarium/pastel/compat/modonomicon/ModonomiconCompat.java
@@ -1,6 +1,8 @@
 package earth.terrarium.pastel.compat.modonomicon;
 
 import com.klikli_dev.modonomicon.book.page.BookPage;
+import com.klikli_dev.modonomicon.book.page.BookSpotlightPage;
+import com.klikli_dev.modonomicon.client.render.page.BookSpotlightPageRenderer;
 import com.klikli_dev.modonomicon.client.render.page.PageRendererRegistry;
 import com.klikli_dev.modonomicon.data.BookConditionJsonLoader;
 import com.klikli_dev.modonomicon.data.BookPageJsonLoader;
@@ -29,6 +31,7 @@ import earth.terrarium.pastel.compat.modonomicon.client.pages.BookStatusEffectPa
 import earth.terrarium.pastel.compat.modonomicon.client.pages.BookTitrationBarrelFermentingPageRenderer;
 import earth.terrarium.pastel.compat.modonomicon.page_types.WebLinkEntry;
 import earth.terrarium.pastel.compat.modonomicon.pages.BookChecklistPage;
+import earth.terrarium.pastel.compat.modonomicon.pages.BookCloakedSpotlightPage;
 import earth.terrarium.pastel.compat.modonomicon.pages.BookCollectionPage;
 import earth.terrarium.pastel.compat.modonomicon.pages.BookGatedRecipePage;
 import earth.terrarium.pastel.compat.modonomicon.pages.BookHintPage;
@@ -123,6 +126,8 @@ public class ModonomiconCompat extends PastelIntegrationPacks.ModIntegrationPack
 
     public static final ResourceLocation PRIMORDIAL_FIRE_BURNING_PAGE = PastelCommon.locate("primordial_fire_burning");
 
+    public static final ResourceLocation CLOAKED_SPOTLIGHT_PAGE = PastelCommon.locate("cloaked_spotlight");
+
     // Unlock Conditions
     public static final ResourceLocation ENCHANTMENT_REGISTERED = PastelCommon.locate("enchantment_registered");
 
@@ -199,6 +204,13 @@ public class ModonomiconCompat extends PastelIntegrationPacks.ModIntegrationPack
                 (BookPageJsonLoader<?>) BookCollectionPage::fromJson,
                 BookCollectionPage::fromNetwork
             );
+
+        LoaderRegistry
+                .registerPageLoader(
+                        CLOAKED_SPOTLIGHT_PAGE,
+                        (BookPageJsonLoader<?>)BookCloakedSpotlightPage::fromJson,
+                        BookCloakedSpotlightPage::fromNetwork
+                );
     }
 
     private void registerGatedRecipePage(
@@ -393,6 +405,12 @@ public class ModonomiconCompat extends PastelIntegrationPacks.ModIntegrationPack
                     }
                 }
             );
+
+        PageRendererRegistry
+                .registerPageRenderer(
+                        CLOAKED_SPOTLIGHT_PAGE,
+                        p -> new BookSpotlightPageRenderer((BookSpotlightPage) p)
+                );
     }
 
 }

--- a/src/main/java/earth/terrarium/pastel/compat/modonomicon/ModonomiconCompat.java
+++ b/src/main/java/earth/terrarium/pastel/compat/modonomicon/ModonomiconCompat.java
@@ -206,11 +206,11 @@ public class ModonomiconCompat extends PastelIntegrationPacks.ModIntegrationPack
             );
 
         LoaderRegistry
-                .registerPageLoader(
-                        CLOAKED_SPOTLIGHT_PAGE,
-                        (BookPageJsonLoader<?>)BookCloakedSpotlightPage::fromJson,
-                        BookCloakedSpotlightPage::fromNetwork
-                );
+            .registerPageLoader(
+                CLOAKED_SPOTLIGHT_PAGE,
+                (BookPageJsonLoader<?>) BookCloakedSpotlightPage::fromJson,
+                BookCloakedSpotlightPage::fromNetwork
+            );
     }
 
     private void registerGatedRecipePage(
@@ -407,10 +407,10 @@ public class ModonomiconCompat extends PastelIntegrationPacks.ModIntegrationPack
             );
 
         PageRendererRegistry
-                .registerPageRenderer(
-                        CLOAKED_SPOTLIGHT_PAGE,
-                        p -> new BookSpotlightPageRenderer((BookSpotlightPage) p)
-                );
+            .registerPageRenderer(
+                CLOAKED_SPOTLIGHT_PAGE,
+                p -> new BookSpotlightPageRenderer((BookSpotlightPage) p)
+            );
     }
 
 }

--- a/src/main/java/earth/terrarium/pastel/compat/modonomicon/pages/BookCloakedSpotlightPage.java
+++ b/src/main/java/earth/terrarium/pastel/compat/modonomicon/pages/BookCloakedSpotlightPage.java
@@ -1,5 +1,6 @@
 package earth.terrarium.pastel.compat.modonomicon.pages;
 
+import com.cmdpro.databank.hidden.types.ItemHiddenType;
 import com.google.gson.JsonObject;
 import com.klikli_dev.modonomicon.book.BookTextHolder;
 import com.klikli_dev.modonomicon.book.conditions.BookCondition;
@@ -81,7 +82,12 @@ public class BookCloakedSpotlightPage extends BookSpotlightPage {
 
     @Override
     public void build(Level level, BookContentEntry parentEntry, int pageNum) {
-        wasTitleUnspecified = this.title.isEmpty();
+
+        var item = this.item.map(ItemStack::getItem, i -> i.getItems()[0].getItem());
+        if (ItemHiddenType.getHiddenItem(item) != null) {
+            // Only check if we actually have a cloak
+            wasTitleUnspecified = this.title.isEmpty();
+        }
         super.build(level, parentEntry, pageNum);
     }
 }

--- a/src/main/java/earth/terrarium/pastel/compat/modonomicon/pages/BookCloakedSpotlightPage.java
+++ b/src/main/java/earth/terrarium/pastel/compat/modonomicon/pages/BookCloakedSpotlightPage.java
@@ -1,0 +1,71 @@
+package earth.terrarium.pastel.compat.modonomicon.pages;
+
+import com.google.gson.JsonObject;
+import com.klikli_dev.modonomicon.book.BookTextHolder;
+import com.klikli_dev.modonomicon.book.conditions.BookCondition;
+import com.klikli_dev.modonomicon.book.conditions.BookNoneCondition;
+import com.klikli_dev.modonomicon.book.entries.BookContentEntry;
+import com.klikli_dev.modonomicon.book.page.BookSpotlightPage;
+import com.klikli_dev.modonomicon.util.BookGsonHelper;
+import com.mojang.datafixers.util.Either;
+import com.mojang.serialization.JsonOps;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.Style;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.level.Level;
+
+public class BookCloakedSpotlightPage extends BookSpotlightPage {
+    private boolean wasTitleUnspecified = false;
+
+    public BookCloakedSpotlightPage(BookTextHolder title, BookTextHolder text, Either<ItemStack, Ingredient> item, String anchor, BookCondition condition) {
+        super(title, text, item, anchor, condition);
+    }
+
+    public static BookCloakedSpotlightPage fromJson(ResourceLocation entryId, JsonObject json, HolderLookup.Provider provider) {
+        var title = BookGsonHelper.getAsBookTextHolder(json, "title", BookTextHolder.EMPTY, provider);
+        var item = ITEM_CODEC.parse(provider.createSerializationContext(JsonOps.INSTANCE), json.get("item")).result().get();
+        var text = BookGsonHelper.getAsBookTextHolder(json, "text", BookTextHolder.EMPTY, provider);
+        var anchor = GsonHelper.getAsString(json, "anchor", "");
+        var condition = json.has("condition")
+                ? BookCondition.fromJson(entryId, json.getAsJsonObject("condition"), provider)
+                : new BookNoneCondition();
+        return new BookCloakedSpotlightPage(title, text, item, anchor, condition);
+    }
+
+    public static BookCloakedSpotlightPage fromNetwork(RegistryFriendlyByteBuf buffer) {
+        var title = BookTextHolder.fromNetwork(buffer);
+        var item = ITEM_STREAM_CODEC.decode(buffer);
+        var text = BookTextHolder.fromNetwork(buffer);
+        var anchor = buffer.readUtf();
+        var condition = BookCondition.fromNetwork(buffer);
+        return new BookCloakedSpotlightPage(title, text, item, anchor, condition);
+    }
+
+    // _Always_ recalculate an items hover name, if we are basing it off that
+    @Override
+    public BookTextHolder getTitle() {
+        if (this.wasTitleUnspecified) {
+            var item = this.item.map(i -> i, i -> i.getItems()[0]);
+
+            return new BookTextHolder(item.getHoverName().copy()
+                        .withStyle(Style.EMPTY
+                                .withBold(true)
+                                .withColor(this.getParentEntry().getBook().getDefaultTitleColor())
+                        )
+            );
+        } else {
+            return this.title;
+        }
+    }
+
+    @Override
+    public void build(Level level, BookContentEntry parentEntry, int pageNum) {
+        wasTitleUnspecified = this.title.isEmpty();
+        super.build(level, parentEntry, pageNum);
+    }
+}

--- a/src/main/java/earth/terrarium/pastel/compat/modonomicon/pages/BookCloakedSpotlightPage.java
+++ b/src/main/java/earth/terrarium/pastel/compat/modonomicon/pages/BookCloakedSpotlightPage.java
@@ -11,7 +11,6 @@ import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.JsonOps;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.network.RegistryFriendlyByteBuf;
-import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.GsonHelper;
@@ -22,18 +21,31 @@ import net.minecraft.world.level.Level;
 public class BookCloakedSpotlightPage extends BookSpotlightPage {
     private boolean wasTitleUnspecified = false;
 
-    public BookCloakedSpotlightPage(BookTextHolder title, BookTextHolder text, Either<ItemStack, Ingredient> item, String anchor, BookCondition condition) {
+    public BookCloakedSpotlightPage(
+        BookTextHolder title,
+        BookTextHolder text,
+        Either<ItemStack, Ingredient> item,
+        String anchor,
+        BookCondition condition
+    ) {
         super(title, text, item, anchor, condition);
     }
 
-    public static BookCloakedSpotlightPage fromJson(ResourceLocation entryId, JsonObject json, HolderLookup.Provider provider) {
+    public static BookCloakedSpotlightPage fromJson(
+        ResourceLocation entryId,
+        JsonObject json,
+        HolderLookup.Provider provider
+    ) {
         var title = BookGsonHelper.getAsBookTextHolder(json, "title", BookTextHolder.EMPTY, provider);
-        var item = ITEM_CODEC.parse(provider.createSerializationContext(JsonOps.INSTANCE), json.get("item")).result().get();
+        var item = ITEM_CODEC
+            .parse(provider.createSerializationContext(JsonOps.INSTANCE), json.get("item"))
+            .result()
+            .get();
         var text = BookGsonHelper.getAsBookTextHolder(json, "text", BookTextHolder.EMPTY, provider);
         var anchor = GsonHelper.getAsString(json, "anchor", "");
         var condition = json.has("condition")
-                ? BookCondition.fromJson(entryId, json.getAsJsonObject("condition"), provider)
-                : new BookNoneCondition();
+            ? BookCondition.fromJson(entryId, json.getAsJsonObject("condition"), provider)
+            : new BookNoneCondition();
         return new BookCloakedSpotlightPage(title, text, item, anchor, condition);
     }
 
@@ -52,11 +64,15 @@ public class BookCloakedSpotlightPage extends BookSpotlightPage {
         if (this.wasTitleUnspecified) {
             var item = this.item.map(i -> i, i -> i.getItems()[0]);
 
-            return new BookTextHolder(item.getHoverName().copy()
-                        .withStyle(Style.EMPTY
-                                .withBold(true)
-                                .withColor(this.getParentEntry().getBook().getDefaultTitleColor())
-                        )
+            return new BookTextHolder(
+                item
+                    .getHoverName()
+                    .copy()
+                    .withStyle(
+                        Style.EMPTY
+                            .withBold(true)
+                            .withColor(this.getParentEntry().getBook().getDefaultTitleColor())
+                    )
             );
         } else {
             return this.title;

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/brewing/bitter_oils.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/brewing/bitter_oils.json
@@ -16,7 +16,7 @@
   "y": -3,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:bitter_oils"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/brewing/concealing_oils.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/brewing/concealing_oils.json
@@ -16,7 +16,7 @@
   "y": -3,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:concealing_oils"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/brewing/potion_workshop_reagents.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/brewing/potion_workshop_reagents.json
@@ -31,14 +31,14 @@
       "text": "book.pastel.guidebook.potion_workshop_reagents.page1.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "minecraft:redstone"
       },
       "text": "book.pastel.guidebook.potion_workshop_reagents.redstone.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:pure_redstone"
       },
@@ -50,14 +50,14 @@
       "text": "book.pastel.guidebook.potion_workshop_reagents.pure_redstone.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "minecraft:glowstone_dust"
       },
       "text": "book.pastel.guidebook.potion_workshop_reagents.glowstone_dust.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:pure_glowstone"
       },
@@ -69,14 +69,14 @@
       "text": "book.pastel.guidebook.potion_workshop_reagents.pure_glowstone.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "minecraft:lapis_lazuli"
       },
       "text": "book.pastel.guidebook.potion_workshop_reagents.lapis_lazuli.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:pure_lapis"
       },
@@ -88,14 +88,14 @@
       "text": "book.pastel.guidebook.potion_workshop_reagents.pure_lapis.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "minecraft:gunpowder"
       },
       "text": "book.pastel.guidebook.potion_workshop_reagents.gunpowder.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "minecraft:dragon_breath"
       },
@@ -106,7 +106,7 @@
       "text": "book.pastel.guidebook.potion_workshop_reagents.dragon_breath.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "minecraft:echo_shard"
       },
@@ -117,7 +117,7 @@
       "text": "book.pastel.guidebook.potion_workshop_reagents.echo_shard.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:pure_echo"
       },
@@ -129,35 +129,35 @@
       "text": "book.pastel.guidebook.potion_workshop_reagents.pure_echo.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:topaz_powder"
       },
       "text": "book.pastel.guidebook.potion_workshop_reagents.topaz_powder.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:amethyst_powder"
       },
       "text": "book.pastel.guidebook.potion_workshop_reagents.amethyst_powder.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:citrine_powder"
       },
       "text": "book.pastel.guidebook.potion_workshop_reagents.citrine_powder.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:onyx_powder"
       },
       "text": "book.pastel.guidebook.potion_workshop_reagents.onyx_powder.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:moonstone_powder"
       },
@@ -168,14 +168,14 @@
       "text": "book.pastel.guidebook.potion_workshop_reagents.moonstone_powder.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:shimmerstone_gem"
       },
       "text": "book.pastel.guidebook.potion_workshop_reagents.shimmerstone_gem.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:quitoxic_powder"
       },
@@ -186,7 +186,7 @@
       "text": "book.pastel.guidebook.potion_workshop_reagents.quitoxic_powder.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:stratine_fragments"
       },
@@ -197,7 +197,7 @@
       "text": "book.pastel.guidebook.potion_workshop_reagents.stratine_fragments.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:paltaeria_fragments"
       },
@@ -208,7 +208,7 @@
       "text": "book.pastel.guidebook.potion_workshop_reagents.paltaeria_fragments.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:stardust"
       },
@@ -219,7 +219,7 @@
       "text": "book.pastel.guidebook.potion_workshop_reagents.stardust.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:star_fragment"
       },
@@ -230,7 +230,7 @@
       "text": "book.pastel.guidebook.potion_workshop_reagents.star_fragment.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:storm_stone"
       },
@@ -241,7 +241,7 @@
       "text": "book.pastel.guidebook.potion_workshop_reagents.storm_stone.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:raw_azurite"
       },
@@ -252,7 +252,7 @@
       "text": "book.pastel.guidebook.potion_workshop_reagents.raw_azurite.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:four_leaf_clover"
       },
@@ -263,7 +263,7 @@
       "text": "book.pastel.guidebook.potion_workshop_reagents.four_leaf_clover.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:vegetal"
       },
@@ -274,7 +274,7 @@
       "text": "book.pastel.guidebook.potion_workshop_reagents.vegetal.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:neolith"
       },
@@ -285,7 +285,7 @@
       "text": "book.pastel.guidebook.potion_workshop_reagents.neolith.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:midnight_chip"
       },
@@ -296,7 +296,7 @@
       "text": "book.pastel.guidebook.potion_workshop_reagents.midnight_chip.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:moonstruck_nectar"
       },
@@ -307,7 +307,7 @@
       "text": "book.pastel.guidebook.potion_workshop_reagents.moonstruck_nectar.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:bedrock_dust"
       },
@@ -318,7 +318,7 @@
       "text": "book.pastel.guidebook.potion_workshop_reagents.bedrock_dust.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:bismuth_flake"
       },
@@ -329,7 +329,7 @@
       "text": "book.pastel.guidebook.potion_workshop_reagents.bismuth_flake.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:raw_malachite"
       },
@@ -340,7 +340,7 @@
       "text": "book.pastel.guidebook.potion_workshop_reagents.raw_malachite.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:raw_bloodstone"
       },
@@ -351,7 +351,7 @@
       "text": "book.pastel.guidebook.potion_workshop_reagents.raw_bloodstone.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:prickly_bayleaf"
       },
@@ -363,7 +363,7 @@
       "text": "book.pastel.guidebook.potion_workshop_reagents.prickly_bayleaf.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:jadeite_petals"
       },
@@ -375,7 +375,7 @@
       "text": "book.pastel.guidebook.potion_workshop_reagents.jadeite_petals.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:fissure_plum"
       },
@@ -387,7 +387,7 @@
       "text": "book.pastel.guidebook.potion_workshop_reagents.fissure_plum.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:bone_ash"
       },
@@ -399,7 +399,7 @@
       "text": "book.pastel.guidebook.potion_workshop_reagents.bone_ash.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:ash_flakes"
       },
@@ -411,7 +411,7 @@
       "text": "book.pastel.guidebook.potion_workshop_reagents.ash_flakes.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:bitter_oils"
       },
@@ -423,7 +423,7 @@
       "text": "book.pastel.guidebook.potion_workshop_reagents.bitter_oils.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:nightdew_sprout"
       },
@@ -435,7 +435,7 @@
       "text": "book.pastel.guidebook.potion_workshop_reagents.nightdew_sprout.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:nectardew_burgeon"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/creating_life/bloodstone.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/creating_life/bloodstone.json
@@ -21,7 +21,7 @@
   "turnin": "pastel:grow_bloodstone_in_crystallarieum",
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.bloodstone.name",
       "item": {
         "item": "pastel:raw_bloodstone"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/creating_life/dragonbone.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/creating_life/dragonbone.json
@@ -21,7 +21,7 @@
       "title": "block.pastel.dragonbone"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "condition": {
         "type": "modonomicon:advancement",
         "advancement_id": "pastel:break_cracked_dragonbone"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/creating_life/memories.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/creating_life/memories.json
@@ -34,7 +34,7 @@
   "y": 2,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.memories.name",
       "item": {
         "item": "pastel:memory",
@@ -61,7 +61,7 @@
       "text": "book.pastel.guidebook.memories.page2.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "condition": {
         "type": "modonomicon:advancement",
         "advancement_id": "pastel:milestones/unlock_remembering_boss_memories"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/creating_life/resplendent_feathers.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/creating_life/resplendent_feathers.json
@@ -21,7 +21,7 @@
   "y": 3,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "item.pastel.resplendent_feather",
       "item": {
         "item": "pastel:resplendent_feather"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/creating_life/spawner_manipulation.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/creating_life/spawner_manipulation.json
@@ -23,7 +23,7 @@
   "y": 3,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.harvesting_spawners",
       "item": {
         "item": "pastel:resonant_pickaxe"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/cuisine/amaranth.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/cuisine/amaranth.json
@@ -16,7 +16,7 @@
   "y": 0,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:amaranth_grains"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/cuisine/blood_orchid_products.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/cuisine/blood_orchid_products.json
@@ -16,7 +16,7 @@
   "y": 5,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.blood_orchid_products.name",
       "item": {
         "item": "pastel:bloodboil_syrup"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/cuisine/chrysocolla.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/cuisine/chrysocolla.json
@@ -20,7 +20,7 @@
   "y": 2,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:chrysocolla"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/cuisine/crawfish.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/cuisine/crawfish.json
@@ -16,7 +16,7 @@
   "y": 5,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "condition": {
         "type": "modonomicon:advancement",
         "advancement_id": "pastel:hidden/collect_crawfish"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/cuisine/enchanted_star_candy.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/cuisine/enchanted_star_candy.json
@@ -20,7 +20,7 @@
   "y": -2,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "item.pastel.enchanted_star_candy",
       "item": {
         "item": "pastel:enchanted_star_candy"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/cuisine/glistering_melons.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/cuisine/glistering_melons.json
@@ -16,7 +16,7 @@
   "y": 5,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.glistering_melons.page0.title",
       "item": {
         "item": "minecraft:glistering_melon_slice"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/cuisine/jade_wine.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/cuisine/jade_wine.json
@@ -32,7 +32,7 @@
       "text": "book.pastel.guidebook.jade_wine.page1.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.jade_wine.page2.title",
       "condition": {
         "type": "modonomicon:advancement",

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/cuisine/koi.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/cuisine/koi.json
@@ -16,7 +16,7 @@
   "y": 5,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "condition": {
         "type": "modonomicon:advancement",
         "advancement_id": "pastel:hidden/collect_koi"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/cuisine/mermaids_jam.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/cuisine/mermaids_jam.json
@@ -20,7 +20,7 @@
   "y": -3,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:mermaids_jam"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/cuisine/milky_resin.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/cuisine/milky_resin.json
@@ -16,7 +16,7 @@
   "y": 4,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:milky_resin"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/cuisine/pure_alcohol.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/cuisine/pure_alcohol.json
@@ -20,7 +20,7 @@
   "y": 0,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "item.pastel.pure_alcohol",
       "item": {
         "item": "pastel:pure_alcohol"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/cuisine/sawblade_holly.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/cuisine/sawblade_holly.json
@@ -16,7 +16,7 @@
   "y": 5,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:sawblade_holly_berry"
       },
@@ -24,7 +24,7 @@
       "title": "book.pastel.guidebook.sawblade_holly.name"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:prickly_bayleaf"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/decoration/ethereal_platform.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/decoration/ethereal_platform.json
@@ -27,7 +27,7 @@
   "y": 6,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:ethereal_platform"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/decoration/glowblocks.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/decoration/glowblocks.json
@@ -20,7 +20,7 @@
   "y": 7,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:orange_glowblock"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/decoration/radiant_glass.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/decoration/radiant_glass.json
@@ -20,7 +20,7 @@
   "y": 4,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:radiant_glass"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/abyssal_vines.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/abyssal_vines.json
@@ -35,7 +35,7 @@
       "text": "book.pastel.guidebook.abyssal_vines.page2.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "id": "pastel:fissure_plum"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/aether_vestiges.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/aether_vestiges.json
@@ -21,7 +21,7 @@
       "text": "book.pastel.guidebook.aether_vestiges.page0.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.aether_vestiges.page1.title",
       "item": {
         "id": "pastel:aether_vestiges"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/aloe.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/aloe.json
@@ -25,7 +25,7 @@
       "text": "book.pastel.guidebook.aloe.page0.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "id": "pastel:aloe_leaf"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/basal_marble.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/basal_marble.json
@@ -20,7 +20,7 @@
   "y": 10,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "id": "pastel:basal_marble"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/crystal_flowers.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/crystal_flowers.json
@@ -25,21 +25,21 @@
       "text": "book.pastel.guidebook.crystal_flowers.page0.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "id": "pastel:sweet_pea"
       },
       "text": "book.pastel.guidebook.crystal_flowers.page1.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "id": "pastel:apricotti"
       },
       "text": "book.pastel.guidebook.crystal_flowers.page2.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "id": "pastel:humming_bell"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/crystal_gardens.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/crystal_gardens.json
@@ -31,7 +31,7 @@
       "text": "book.pastel.guidebook.crystal_gardens.page0.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "id": "pastel:overgrown_blackslag"
       },
@@ -47,7 +47,7 @@
       "text": "book.pastel.guidebook.crystal_gardens.moss_balls.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "id": "pastel:viridian_crystal"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/delving_deeper_down.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/delving_deeper_down.json
@@ -16,7 +16,7 @@
   "y": 0,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.delving_deeper_down.name",
       "item": {
         "id": "minecraft:bedrock"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/doomblooms.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/doomblooms.json
@@ -25,7 +25,7 @@
       "title": "book.pastel.guidebook.doomblooms.name"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "id": "pastel:doombloom_seed"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/downstone.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/downstone.json
@@ -20,7 +20,7 @@
   "y": 3,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "id": "pastel:downstone"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/downstone_fragments.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/downstone_fragments.json
@@ -24,7 +24,7 @@
   "y": 5,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "item.pastel.downstone_fragments",
       "item": {
         "id": "pastel:downstone_fragments"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/dragonrot_swamp.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/dragonrot_swamp.json
@@ -31,14 +31,14 @@
       "text": "book.pastel.guidebook.dragonrot_swamp.page0.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "id": "pastel:snapping_ivy"
       },
       "text": "book.pastel.guidebook.dragonrot_swamp.page2.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "id": "pastel:flayed_earth"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/howling_spires.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/howling_spires.json
@@ -31,14 +31,14 @@
       "text": "book.pastel.guidebook.howling_spires.page0.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "id": "pastel:ashen_blackslag"
       },
       "text": "book.pastel.guidebook.howling_spires.ashen_blackslag.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "id": "pastel:varia_sprout"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/hummingstone.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/hummingstone.json
@@ -20,14 +20,14 @@
   "y": -1,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "id": "pastel:hummingstone"
       },
       "text": "book.pastel.guidebook.hummingstone.page0.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "id": "pastel:hummingstone_glass"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/jadeite.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/jadeite.json
@@ -21,7 +21,7 @@
   "y": 9,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.jadeite.name",
       "item": {
         "id": "pastel:jadeite_petals"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/moonstone_cores.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/moonstone_cores.json
@@ -20,7 +20,7 @@
   "y": -2,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "id": "pastel:moonstone_core"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/nectar_gloves.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/nectar_gloves.json
@@ -25,7 +25,7 @@
       "title": "item.pastel.aether_graced_nectar_gloves"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "id": "pastel:aether_graced_nectar_gloves"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/nephrite.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/nephrite.json
@@ -25,7 +25,7 @@
       "text": "book.pastel.guidebook.nephrite.page0.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "id": "pastel:glass_peach"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/noxshroom_forest.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/noxshroom_forest.json
@@ -31,7 +31,7 @@
       "text": "book.pastel.guidebook.noxshroom_forest.page0.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "id": "pastel:shimmel"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/poisoners_handbook.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/poisoners_handbook.json
@@ -71,7 +71,7 @@
       "text": "book.pastel.guidebook.poisoners_handbook.page10.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "id": "pastel:nectardew_burgeon"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/pyrite.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/pyrite.json
@@ -20,7 +20,7 @@
   "y": -8,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "id": "pastel:pyrite"
       },
@@ -55,7 +55,7 @@
       "text": "book.pastel.guidebook.pyrite.page2.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.pyrite.page3.title",
       "item": {
         "id": "pastel:pyrite_ripper"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/razor_edge.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/razor_edge.json
@@ -31,14 +31,14 @@
       "text": "book.pastel.guidebook.razor_edge.page0.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "id": "pastel:sawblade_grass"
       },
       "text": "book.pastel.guidebook.razor_edge.page1.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "id": "pastel:bristle_sprouts"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/resonance_shards.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/resonance_shards.json
@@ -20,7 +20,7 @@
   "y": -1,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "id": "pastel:resonance_shard"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/rock_crystal.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/rock_crystal.json
@@ -20,7 +20,7 @@
   "y": -8,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "id": "pastel:rock_crystal"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/shale_clay.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/shale_clay.json
@@ -70,7 +70,7 @@
       "text": "book.pastel.guidebook.turn_back_to_polished"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "id": "pastel:tilled_shale_clay"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/slush.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/slush.json
@@ -20,7 +20,7 @@
   "y": 3,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "id": "pastel:slush"
       },
@@ -28,7 +28,7 @@
       "title": "block.pastel.slush"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "id": "pastel:tilled_slush"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/weeping_gala.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/dimension/weeping_gala.json
@@ -21,7 +21,7 @@
   "y": 10,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "id": "pastel:weeping_gala_sprig"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/conflicting_enchantments.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/conflicting_enchantments.json
@@ -21,7 +21,7 @@
   "y": 2,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.conflicting_enchantments.name",
       "item": {
         "item": "minecraft:diamond_chestplate",

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchanting_items.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchanting_items.json
@@ -35,7 +35,7 @@
       "text": "book.pastel.guidebook.enchanting_items.page1.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "minecraft:enchanted_book"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantment_canvas.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantment_canvas.json
@@ -27,7 +27,7 @@
       "recipe_id": "pastel:pedestal/tier2/enchantment_canvas"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.enchantment_canvas.page2.title",
       "item": {
         "item": "pastel:midnight_solution_bucket"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/big_catch.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/big_catch.json
@@ -31,7 +31,7 @@
       "title": "enchantment.pastel.big_catch"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.enchantment_characteristics",
       "item": {
         "item": "pastel:lagoon_rod"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/clovers_favor.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/clovers_favor.json
@@ -22,7 +22,7 @@
       "title": "enchantment.pastel.clovers_favor"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.enchantment_characteristics",
       "item": {
         "item": "minecraft:iron_sword"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/curse_of_the_void.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/curse_of_the_void.json
@@ -22,7 +22,7 @@
       "title": "enchantment.pastel.voiding"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.enchantment_characteristics",
       "item": {
         "item": "minecraft:iron_pickaxe"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/disarming.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/disarming.json
@@ -22,7 +22,7 @@
       "title": "enchantment.pastel.disarming"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.enchantment_characteristics",
       "item": {
         "item": "minecraft:iron_sword"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/exuberance.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/exuberance.json
@@ -22,7 +22,7 @@
       "title": "enchantment.pastel.exuberance"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.enchantment_characteristics",
       "item": {
         "item": "pastel:multitool"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/first_strike.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/first_strike.json
@@ -22,7 +22,7 @@
       "title": "enchantment.pastel.first_strike"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.enchantment_characteristics",
       "item": {
         "item": "minecraft:iron_sword"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/foundry.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/foundry.json
@@ -22,7 +22,7 @@
       "title": "enchantment.pastel.foundry"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.enchantment_characteristics",
       "item": {
         "item": "minecraft:iron_pickaxe"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/improved_critical.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/improved_critical.json
@@ -22,7 +22,7 @@
       "title": "enchantment.pastel.improved_critical"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.enchantment_characteristics",
       "item": {
         "item": "minecraft:iron_sword"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/indestructible.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/indestructible.json
@@ -22,7 +22,7 @@
       "title": "enchantment.pastel.indestructible"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.enchantment_characteristics",
       "item": {
         "item": "pastel:multitool"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/inertia.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/inertia.json
@@ -22,7 +22,7 @@
       "title": "enchantment.pastel.inertia"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.enchantment_characteristics",
       "item": {
         "item": "minecraft:iron_pickaxe"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/inexorable.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/inexorable.json
@@ -22,7 +22,7 @@
       "title": "enchantment.pastel.inexorable"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.enchantment_characteristics",
       "item": {
         "item": "minecraft:iron_pickaxe"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/inventory_insertion.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/inventory_insertion.json
@@ -22,7 +22,7 @@
       "title": "enchantment.pastel.inventory_insertion"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.enchantment_characteristics",
       "item": {
         "item": "pastel:multitool"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/pest_control.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/pest_control.json
@@ -22,7 +22,7 @@
       "title": "enchantment.pastel.pest_control"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.enchantment_characteristics",
       "item": {
         "item": "minecraft:iron_pickaxe"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/razing.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/razing.json
@@ -22,7 +22,7 @@
       "title": "enchantment.pastel.razing"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.enchantment_characteristics",
       "item": {
         "item": "minecraft:iron_pickaxe"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/resonance.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/resonance.json
@@ -22,7 +22,7 @@
       "title": "enchantment.pastel.resonance"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.enchantment_characteristics",
       "item": {
         "item": "minecraft:iron_pickaxe"
@@ -45,7 +45,7 @@
       "recipe_id": "pastel:enchanter/pastel_books/resonance"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.resonance.page3.title",
       "item": {
         "item": "minecraft:medium_amethyst_bud"
@@ -53,7 +53,7 @@
       "text": "book.pastel.guidebook.resonance.page3.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.pure_resources.name",
       "item": {
         "item": "pastel:pure_iron"
@@ -65,7 +65,7 @@
       "text": "book.pastel.guidebook.resonance.page4.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "",
       "item": {
         "item": "pastel:orange_leaves"
@@ -73,7 +73,7 @@
       "text": "book.pastel.guidebook.resonance.page5.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.harvesting_spawners",
       "item": {
         "item": "minecraft:spawner"
@@ -81,14 +81,14 @@
       "text": "book.pastel.guidebook.resonance.page6.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "minecraft:reinforced_deepslate"
       },
       "text": "book.pastel.guidebook.resonance.page7.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "minecraft:sculk_shrieker"
       },
@@ -104,14 +104,14 @@
       "text": "book.pastel.guidebook.resonance.page9.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "minecraft:respawn_anchor"
       },
       "text": "book.pastel.guidebook.resonance.page10.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.resonance.page11.title",
       "item": {
         "item": "minecraft:oak_sign"
@@ -119,7 +119,7 @@
       "text": "book.pastel.guidebook.resonance.page11.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.resonance.page12.title",
       "item": {
         "item": "minecraft:infested_stone_bricks"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/serendipity_reel.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/serendipity_reel.json
@@ -31,7 +31,7 @@
       "title": "book.pastel.guidebook.serendipity_reel.name"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.enchantment_characteristics",
       "item": {
         "item": "pastel:lagoon_rod"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/steadfast.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/steadfast.json
@@ -22,7 +22,7 @@
       "title": "enchantment.pastel.steadfast"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.enchantment_characteristics",
       "item": {
         "item": "pastel:multitool"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/tight_grip.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/tight_grip.json
@@ -22,7 +22,7 @@
       "title": "enchantment.pastel.tight_grip"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.enchantment_characteristics",
       "item": {
         "item": "minecraft:iron_sword"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/treasure_hunter.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/enchantments/treasure_hunter.json
@@ -22,7 +22,7 @@
       "title": "enchantment.pastel.treasure_hunter"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.treasure_hunter.page1.title",
       "item": {
         "item": "pastel:cow_head"
@@ -30,7 +30,7 @@
       "text": "book.pastel.guidebook.treasure_hunter.page1.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.enchantment_characteristics",
       "item": {
         "item": "minecraft:iron_axe"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/gilded_book.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/gilded_book.json
@@ -16,7 +16,7 @@
   "y": 0,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:gilded_book"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/overchanting.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/enchanting/overchanting.json
@@ -19,7 +19,7 @@
   "y": -2,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.overchanting.name",
       "item": {
         "item": "minecraft:enchanted_book",

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/equipment/bag_of_holding.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/equipment/bag_of_holding.json
@@ -16,7 +16,7 @@
   "y": 5,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "item.pastel.bag_of_holding",
       "item": {
         "item": "pastel:bag_of_holding"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/equipment/bottomless_bundle.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/equipment/bottomless_bundle.json
@@ -16,7 +16,7 @@
   "y": 5,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:bottomless_bundle"
       },
@@ -43,7 +43,7 @@
       "text": "book.pastel.guidebook.bottomless_bundle.page3.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "condition": {
         "type": "modonomicon:advancement",
         "advancement_id": "pastel:midgame/build_enchanting_structure"
@@ -60,7 +60,7 @@
       "text": "book.pastel.guidebook.bottomless_bundle.page4.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "condition": {
         "type": "modonomicon:advancement",
         "advancement_id": "pastel:midgame/build_enchanting_structure"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/equipment/ender_canvas.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/equipment/ender_canvas.json
@@ -20,7 +20,7 @@
   "y": 6,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:ender_canvas"
       },
@@ -40,7 +40,7 @@
       "recipe_id": "pastel:pedestal/tier3/ender_canvas_large"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "condition": {
         "type": "modonomicon:advancement",
         "advancement_id": "pastel:lategame/craft_resonant_tool"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/equipment/ender_splice.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/equipment/ender_splice.json
@@ -16,7 +16,7 @@
   "y": 5,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:ender_splice"
       },
@@ -30,7 +30,7 @@
       "recipe_id": "pastel:pedestal/tier3/ender_splice"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "condition": {
         "type": "modonomicon:advancement",
         "advancement_id": "pastel:midgame/build_enchanting_structure"
@@ -47,7 +47,7 @@
       "text": "book.pastel.guidebook.ender_splice.page2.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "condition": {
         "type": "modonomicon:advancement",
         "advancement_id": "pastel:lategame/create_resonant_tool"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/equipment/exchanging_staff.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/equipment/exchanging_staff.json
@@ -27,7 +27,7 @@
       "recipe_id": "pastel:pedestal/tier3/exchanging_staff"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "condition": {
         "type": "modonomicon:advancement",
         "advancement_id": "pastel:midgame/build_enchanting_structure"
@@ -44,7 +44,7 @@
       "text": "book.pastel.guidebook.exchanging_staff.page2.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "condition": {
         "type": "modonomicon:advancement",
         "advancement_id": "pastel:midgame/build_enchanting_structure"
@@ -61,7 +61,7 @@
       "text": "book.pastel.guidebook.exchanging_staff.page3.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "condition": {
         "type": "modonomicon:advancement",
         "advancement_id": "pastel:unlocks/enchantments/resonance_usage"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/equipment/flowing_staff.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/equipment/flowing_staff.json
@@ -27,7 +27,7 @@
       "recipe_id": "pastel:pedestal/tier2/flowing_staff"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "condition": {
         "type": "modonomicon:advancement",
         "advancement_id": "pastel:lategame/craft_resonant_tool"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/equipment/natures_staff.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/equipment/natures_staff.json
@@ -27,7 +27,7 @@
       "recipe_id": "pastel:pedestal/tier2/natures_staff"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "condition": {
         "type": "modonomicon:advancement",
         "advancement_id": "pastel:midgame/build_enchanting_structure"
@@ -44,7 +44,7 @@
       "text": "book.pastel.guidebook.natures_staff.page2.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "condition": {
         "type": "modonomicon:advancement",
         "advancement_id": "pastel:midgame/build_enchanting_structure"
@@ -61,7 +61,7 @@
       "text": "book.pastel.guidebook.natures_staff.page3.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "condition": {
         "type": "modonomicon:advancement",
         "advancement_id": "pastel:midgame/build_enchanting_structure"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/equipment/tools_and_armor/draconic_twinsword.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/equipment/tools_and_armor/draconic_twinsword.json
@@ -30,7 +30,7 @@
       "text": "book.pastel.guidebook.draconic_twinsword.page2.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:draconic_twinsword"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/equipment/tools_and_armor/multitool.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/equipment/tools_and_armor/multitool.json
@@ -16,7 +16,7 @@
   "y": 0,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:multitool"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/equipment/trinkets/gleaming_pin.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/equipment/trinkets/gleaming_pin.json
@@ -32,7 +32,7 @@
       "recipe_id": "pastel:fusion_shrine/trinkets/gleaming_pin"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "condition": {
         "type": "modonomicon:advancement",
         "advancement_id": "pastel:unlocks/enchantments/piercing"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/equipment/trinkets/priscillent_spectacles.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/equipment/trinkets/priscillent_spectacles.json
@@ -21,7 +21,7 @@
   "y": 4,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:priscillent_spectacles"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/equipment/trinkets/seven_league_boots.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/equipment/trinkets/seven_league_boots.json
@@ -32,7 +32,7 @@
       "text": "book.pastel.guidebook.seven_league_boots.page1.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "condition": {
         "type": "modonomicon:advancement",
         "advancement_id": "pastel:unlocks/enchantments/vanilla_projectile"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/equipment/trinkets/takeoff_belt.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/equipment/trinkets/takeoff_belt.json
@@ -32,7 +32,7 @@
       "text": "book.pastel.guidebook.takeoff_belt.page1.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "condition": {
         "type": "modonomicon:advancement",
         "advancement_id": "pastel:unlocks/enchantments/vanilla_projectile"
@@ -49,7 +49,7 @@
       "text": "book.pastel.guidebook.takeoff_belt.page2.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "condition": {
         "type": "modonomicon:advancement",
         "advancement_id": "pastel:unlocks/enchantments/vanilla_quitoxic"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/azurite.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/azurite.json
@@ -17,7 +17,7 @@
   "turnin": "pastel:midgame/grow_azurite_in_crystallarieum",
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.azurite.name",
       "item": {
         "item": "pastel:raw_azurite"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/bedrock_dust.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/bedrock_dust.json
@@ -20,7 +20,7 @@
   "y": 1,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "item.pastel.bedrock_dust",
       "item": {
         "item": "pastel:bedrock_dust"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/blood_orchid.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/blood_orchid.json
@@ -23,7 +23,7 @@
   "y": 6,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "block.pastel.blood_orchid",
       "item": {
         "item": "pastel:blood_orchid"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/blood_orchid_petal.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/blood_orchid_petal.json
@@ -20,7 +20,7 @@
   "y": 6,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:blood_orchid_petal"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/clover.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/clover.json
@@ -16,7 +16,7 @@
   "y": -3,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "block.pastel.clover",
       "item": {
         "item": "pastel:clover"
@@ -24,7 +24,7 @@
       "text": "book.pastel.guidebook.clover.clover.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:four_leaf_clover"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/crystallisation.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/crystallisation.json
@@ -21,7 +21,7 @@
   "y": 4,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "condition": {
         "type": "modonomicon:advancement",
         "advancement_id": "pastel:hidden/collect_blazing_crystal"
@@ -43,7 +43,7 @@
       "text": "book.pastel.guidebook.liquid_crystal_essences.page1.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "condition": {
         "type": "modonomicon:advancement",
         "advancement_id": "pastel:hidden/collect_frostbite_crystal"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/dark_stakes.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/dark_stakes.json
@@ -23,7 +23,7 @@
   "y": -3,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:dark_stake"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/decay_away.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/decay_away.json
@@ -24,7 +24,7 @@
   "pages": [
     {
       "title": "block.pastel.decay_away",
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:bottle_of_decay_away"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/failing.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/failing.json
@@ -24,7 +24,7 @@
   "turnin": "pastel:midgame/collect_neolith",
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:bottle_of_failing"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/geodes.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/geodes.json
@@ -56,7 +56,7 @@
       "text": "book.pastel.guidebook.geodes.page3.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "condition": {
         "type": "modonomicon:advancement",
         "advancement_id": "pastel:hidden/collect_shards/topaz"
@@ -68,7 +68,7 @@
       "text": "book.pastel.guidebook.geodes.page4.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "condition": {
         "type": "modonomicon:advancement",
         "advancement_id": "pastel:hidden/collect_shards/amethyst"
@@ -80,7 +80,7 @@
       "text": "book.pastel.guidebook.geodes.page5.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "condition": {
         "type": "modonomicon:advancement",
         "advancement_id": "pastel:hidden/collect_shards/citrine"
@@ -92,7 +92,7 @@
       "text": "book.pastel.guidebook.geodes.page6.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "condition": {
         "type": "modonomicon:advancement",
         "advancement_id": "pastel:lategame/collect_moonstone"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/jade_vines.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/jade_vines.json
@@ -20,7 +20,7 @@
   "y": 8,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "block.pastel.jade_vines",
       "item": {
         "item": "pastel:hibernating_jade_vine_bulb"
@@ -38,7 +38,7 @@
       "text": "book.pastel.guidebook.jade_vines.page1.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.jade_vines.page2.title",
       "item": {
         "item": "pastel:germinated_jade_vine_bulb"
@@ -50,7 +50,7 @@
       "text": "book.pastel.guidebook.jade_vines.page2.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "item.pastel.jade_jelly",
       "anchor": "jade_jelly",
       "item": {
@@ -74,7 +74,7 @@
       "text": "book.pastel.guidebook.jade_vines.page4.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.jade_vines.page5.title",
       "anchor": "petals",
       "item": {
@@ -87,7 +87,7 @@
       "text": "book.pastel.guidebook.jade_vines.page5.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "item.pastel.moonstruck_nectar",
       "anchor": "nectar",
       "item": {

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/liquid_crystal.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/liquid_crystal.json
@@ -24,7 +24,7 @@
   "turnin": "pastel:midgame/enter_liquid_crystal",
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "block.pastel.liquid_crystal",
       "item": {
         "item": "pastel:liquid_crystal_bucket"
@@ -38,7 +38,7 @@
       "text": "book.pastel.guidebook.liquid_crystal.page1.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "minecraft:clay"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/mermaids_brush.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/mermaids_brush.json
@@ -21,7 +21,7 @@
       "text": "book.pastel.guidebook.mermaids_brush.page0.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.mermaids_brush.page1.title",
       "item": {
         "item": "pastel:mermaids_gem"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/midnight_aberration.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/midnight_aberration.json
@@ -21,7 +21,7 @@
   "y": 1,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "item.pastel.midnight_aberration",
       "item": {
         "item": "pastel:midnight_aberration"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/midnight_chip.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/midnight_chip.json
@@ -23,7 +23,7 @@
   "y": 0,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:midnight_chip"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/midnight_solution.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/midnight_solution.json
@@ -37,7 +37,7 @@
       "text": "book.pastel.guidebook.midnight_solution.page5.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:black_materia"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/moonstone_shards.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/moonstone_shards.json
@@ -16,7 +16,7 @@
   "y": 7,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.moonstone_shards.name",
       "item": {
         "item": "pastel:moonstone_shard"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/mysterious_locket.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/mysterious_locket.json
@@ -26,7 +26,7 @@
   "y": 10,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.mysterious_locket.name",
       "item": {
         "item": "pastel:mysterious_locket"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/nectardew_burgeon.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/nectardew_burgeon.json
@@ -20,7 +20,7 @@
   "y": -6,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.nectardew_burgeon.name",
       "item": {
         "item": "pastel:nectardew_burgeon"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/neolith.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/neolith.json
@@ -20,7 +20,7 @@
   "y": 1,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "item.pastel.neolith",
       "item": {
         "item": "pastel:neolith"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/nightdew_sprout.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/nightdew_sprout.json
@@ -16,7 +16,7 @@
   "y": -4,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.nightdew_sprout.name",
       "item": {
         "item": "pastel:nightdew_sprout"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/paltaeria.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/paltaeria.json
@@ -20,7 +20,7 @@
   "y": 3,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.paltaeria.name",
       "item": {
         "item": "pastel:paltaeria_fragments"
@@ -38,7 +38,7 @@
       "text": "book.pastel.guidebook.rare_intact_gem"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "block.pastel.paltaeria_floatblock",
       "condition": {
         "type": "modonomicon:advancement",

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/pedestal.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/pedestal.json
@@ -73,7 +73,7 @@
       "text": "book.pastel.guidebook.pedestal.page2.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "condition": {
         "type": "modonomicon:advancement",
         "advancement_id": "pastel:unlocks/items/crafting_tablet"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/pigment.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/pigment.json
@@ -49,7 +49,7 @@
       "text": "book.pastel.guidebook.pigment.page1.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "anchor": "black",
       "condition": {
         "type": "modonomicon:advancement",
@@ -62,7 +62,7 @@
       "text": "book.pastel.guidebook.pigment.page2.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "anchor": "blue",
       "condition": {
         "type": "modonomicon:advancement",
@@ -75,7 +75,7 @@
       "text": "book.pastel.guidebook.pigment.page3.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "anchor": "brown",
       "condition": {
         "type": "modonomicon:advancement",
@@ -88,7 +88,7 @@
       "text": "book.pastel.guidebook.pigment.page4.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "anchor": "cyan",
       "condition": {
         "type": "modonomicon:advancement",
@@ -101,7 +101,7 @@
       "text": "book.pastel.guidebook.pigment.page5.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "anchor": "gray",
       "condition": {
         "type": "modonomicon:advancement",
@@ -114,7 +114,7 @@
       "text": "book.pastel.guidebook.pigment.page6.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "anchor": "green",
       "condition": {
         "type": "modonomicon:advancement",
@@ -127,7 +127,7 @@
       "text": "book.pastel.guidebook.pigment.page7.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "anchor": "light_blue",
       "condition": {
         "type": "modonomicon:advancement",
@@ -140,7 +140,7 @@
       "text": "book.pastel.guidebook.pigment.page8.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "anchor": "black",
       "condition": {
         "type": "modonomicon:advancement",
@@ -153,7 +153,7 @@
       "text": "book.pastel.guidebook.pigment.page9.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "anchor": "lime",
       "condition": {
         "type": "modonomicon:advancement",
@@ -166,7 +166,7 @@
       "text": "book.pastel.guidebook.pigment.page10.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "anchor": "magenta",
       "condition": {
         "type": "modonomicon:advancement",
@@ -179,7 +179,7 @@
       "text": "book.pastel.guidebook.pigment.page11.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "anchor": "orange",
       "condition": {
         "type": "modonomicon:advancement",
@@ -192,7 +192,7 @@
       "text": "book.pastel.guidebook.pigment.page12.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "anchor": "pink",
       "condition": {
         "type": "modonomicon:advancement",
@@ -205,7 +205,7 @@
       "text": "book.pastel.guidebook.pigment.page13.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "anchor": "purple",
       "condition": {
         "type": "modonomicon:advancement",
@@ -218,7 +218,7 @@
       "text": "book.pastel.guidebook.pigment.page14.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "anchor": "red",
       "condition": {
         "type": "modonomicon:advancement",
@@ -231,7 +231,7 @@
       "text": "book.pastel.guidebook.pigment.page15.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "anchor": "white",
       "condition": {
         "type": "modonomicon:advancement",
@@ -244,7 +244,7 @@
       "text": "book.pastel.guidebook.pigment.page16.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "anchor": "yellow",
       "condition": {
         "type": "modonomicon:advancement",

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/preservation_ruins.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/preservation_ruins.json
@@ -17,7 +17,7 @@
   "y": 7,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.preservation_ruins.name",
       "item": {
         "item": "pastel:preservation_controller"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/radiating_ender.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/radiating_ender.json
@@ -21,7 +21,7 @@
       "title": "block.pastel.radiating_ender"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "block.pastel.radiating_ender",
       "item": {
         "item": "pastel:radiating_ender"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/resonant_lily.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/resonant_lily.json
@@ -21,7 +21,7 @@
   "y": 4,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:resonant_lily"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/ruin.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/ruin.json
@@ -21,7 +21,7 @@
   "turnin": "pastel:midgame/break_decayed_bedrock",
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:bottle_of_ruin"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/shards.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/shards.json
@@ -29,7 +29,7 @@
       "type": "modonomicon:empty"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "anchor": "topaz",
       "condition": {
         "type": "modonomicon:advancement",
@@ -58,7 +58,7 @@
       "text": "book.pastel.guidebook.shards.illustration.topaz.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "anchor": "amethyst",
       "condition": {
         "type": "modonomicon:advancement",
@@ -87,7 +87,7 @@
       "text": "book.pastel.guidebook.shards.illustration.amethyst.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "anchor": "citrine",
       "condition": {
         "type": "modonomicon:advancement",
@@ -116,7 +116,7 @@
       "text": "book.pastel.guidebook.shards.illustration.citrine.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "anchor": "onyx",
       "condition": {
         "type": "modonomicon:advancement",
@@ -145,7 +145,7 @@
       "text": "book.pastel.guidebook.shards.illustration.onyx.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "anchor": "moonstone",
       "condition": {
         "type": "modonomicon:advancement",

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/shimmerstone.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/shimmerstone.json
@@ -16,7 +16,7 @@
   "y": 3,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "Shimmerstone",
       "item": {
         "item": "pastel:shimmerstone_gem"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/stargazing.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/stargazing.json
@@ -30,7 +30,7 @@
       "text": "book.pastel.guidebook.stargazing.page0.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "condition": {
         "type": "modonomicon:advancement",
         "advancement_id": "pastel:collect_star_fragment"
@@ -52,7 +52,7 @@
       "text": "book.pastel.guidebook.stargazing.page2.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "condition": {
         "type": "modonomicon:advancement",
         "advancement_id": "pastel:collect_star_fragment"
@@ -64,7 +64,7 @@
       "text": "book.pastel.guidebook.stargazing.page3.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "condition": {
         "type": "modonomicon:advancement",
         "advancement_id": "pastel:collect_star_fragment"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/storm_stones.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/storm_stones.json
@@ -21,7 +21,7 @@
       "text": "book.pastel.guidebook.storm_stones.page0.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.storm_stones.name",
       "item": {
         "item": "pastel:storm_stone"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/stratine.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/stratine.json
@@ -16,7 +16,7 @@
   "y": -2,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.stratine.name",
       "item": {
         "item": "pastel:stratine_fragments"
@@ -34,7 +34,7 @@
       "text": "book.pastel.guidebook.rare_intact_gem"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "block.pastel.stratine_floatblock",
       "condition": {
         "type": "modonomicon:advancement",

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/teatable.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/teatable.json
@@ -20,7 +20,7 @@
   "y": 1,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:tea_table"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/vegetal.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/general/vegetal.json
@@ -20,7 +20,7 @@
   "y": 2,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "item.pastel.vegetal",
       "item": {
         "item": "pastel:vegetal"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/magical_blocks/block_breaker.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/magical_blocks/block_breaker.json
@@ -16,7 +16,7 @@
   "y": 1,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:block_breaker"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/magical_blocks/block_detector.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/magical_blocks/block_detector.json
@@ -16,7 +16,7 @@
   "y": 1,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:block_detector"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/magical_blocks/block_placer.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/magical_blocks/block_placer.json
@@ -16,7 +16,7 @@
   "y": 1,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:block_placer"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/magical_blocks/ender_dropper.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/magical_blocks/ender_dropper.json
@@ -16,7 +16,7 @@
   "y": 2,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "block.pastel.ender_dropper",
       "item": {
         "item": "pastel:ender_dropper"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/magical_blocks/ender_glass.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/magical_blocks/ender_glass.json
@@ -16,7 +16,7 @@
   "y": 3,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:ender_glass"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/magical_blocks/ender_hopper.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/magical_blocks/ender_hopper.json
@@ -16,7 +16,7 @@
   "y": 2,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "block.pastel.ender_hopper",
       "item": {
         "item": "pastel:ender_hopper"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/magical_blocks/fabrication_chest.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/magical_blocks/fabrication_chest.json
@@ -16,7 +16,7 @@
   "y": 0,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:fabrication_chest"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/magical_blocks/heartbound_chest.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/magical_blocks/heartbound_chest.json
@@ -16,7 +16,7 @@
   "y": 0,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:heartbound_chest"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/magical_blocks/hoverblock.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/magical_blocks/hoverblock.json
@@ -16,7 +16,7 @@
   "y": 0,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:hoverblock"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/magical_blocks/humus.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/magical_blocks/humus.json
@@ -16,7 +16,7 @@
   "y": 0,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "block.pastel.humus",
       "item": {
         "item": "pastel:humus_bucket"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/magical_blocks/redstone_calculator.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/magical_blocks/redstone_calculator.json
@@ -16,7 +16,7 @@
   "y": 5,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:redstone_calculator"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/magical_blocks/redstone_sand.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/magical_blocks/redstone_sand.json
@@ -16,7 +16,7 @@
   "y": 3,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:redstone_sand"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/magical_blocks/redstone_timer.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/magical_blocks/redstone_timer.json
@@ -16,7 +16,7 @@
   "y": 5,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:redstone_timer"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/magical_blocks/redstone_transceiver.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/magical_blocks/redstone_transceiver.json
@@ -16,7 +16,7 @@
   "y": 5,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:redstone_transceiver"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/magical_blocks/semi_permeable_glass.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/magical_blocks/semi_permeable_glass.json
@@ -16,7 +16,7 @@
   "y": 1,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "block.pastel.semi_permeable_glass",
       "item": {
         "item": "pastel:amethyst_semi_permeable_glass"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/00_00_ae2.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/00_00_ae2.json
@@ -28,7 +28,7 @@
       "title": "book.pastel.guidebook.mod_integration.ae2.name"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.mod_integration.ae2.page1.title",
       "item": {
         "item": "ae2:growth_accelerator"
@@ -36,7 +36,7 @@
       "text": "book.pastel.guidebook.mod_integration.ae2.page1.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.mod_integration.ae2.page2.title",
       "item": {
         "item": "ae2:quartz_cluster"
@@ -48,7 +48,7 @@
       "text": "book.pastel.guidebook.mod_integration.ae2.page2.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.mod_integration.ae2.page3.title",
       "condition": {
         "type": "modonomicon:advancement",

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/02_02_create.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/02_02_create.json
@@ -78,7 +78,7 @@
       "recipe_id": "pastel:mod_integration/create/enchantment_upgrade/capacity/1_to_2"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "container.pastel.rei.anvil_crushing.title",
       "condition": {
         "type": "modonomicon:advancement",
@@ -90,7 +90,7 @@
       "text": "book.pastel.guidebook.mod_integration.create.page1.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.mod_integration.create.page2.title",
       "condition": {
         "type": "modonomicon:advancement",
@@ -102,7 +102,7 @@
       "text": "book.pastel.guidebook.mod_integration.create.page2.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "container.pastel.rei.anvil_crushing.title",
       "condition": {
         "type": "modonomicon:advancement",
@@ -114,7 +114,7 @@
       "text": "book.pastel.guidebook.mod_integration.create.page3.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.mod_integration.create.page4.title",
       "condition": {
         "type": "modonomicon:advancement",
@@ -126,7 +126,7 @@
       "text": "book.pastel.guidebook.mod_integration.create.page4.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.mod_integration.create.page5.title",
       "condition": {
         "type": "modonomicon:advancement",
@@ -138,7 +138,7 @@
       "text": "book.pastel.guidebook.mod_integration.create.page5.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.mod_integration.create.page6.title",
       "condition": {
         "type": "modonomicon:advancement",
@@ -150,7 +150,7 @@
       "text": "book.pastel.guidebook.mod_integration.create.page6.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.mod_integration.create.page7.title",
       "condition": {
         "type": "modonomicon:advancement",

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/02_04_hexcasting.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/02_04_hexcasting.json
@@ -56,7 +56,7 @@
       "recipe_id": "pastel:mod_integration/hexcasting/fusion_shrine/charged_amethyst_from_amethyst_shard_fusion"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.potion_reagent",
       "condition": {
         "type": "modonomicon:advancement",

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/04_00_biomemakeover.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/04_00_biomemakeover.json
@@ -46,7 +46,7 @@
       "recipe_id": "pastel:mod_integration/biomemakeover/potion_workshop_brewing/nocturnal"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.mod_integration.biomemakeover.page3.title",
       "item": {
         "item": "biomemakeover:illunite_shard"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/04_05_little_ants.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/04_05_little_ants.json
@@ -30,7 +30,7 @@
       "title": "book.pastel.guidebook.mod_integration.little_ants.name"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:jade_petal_block"
       },
@@ -41,7 +41,7 @@
       "text": "book.pastel.guidebook.mod_integration.little_ants.page1.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "minecraft:orange_dye"
       },
@@ -52,7 +52,7 @@
       "text": "book.pastel.guidebook.mod_integration.little_ants.page2.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:orange_pigment"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/04_06_vein_mining.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/04_06_vein_mining.json
@@ -25,7 +25,7 @@
   "y": 6,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.mod_integration.vein_mining.name",
       "item": {
         "item": "pastel:multitool"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/04_07_tconstruct.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/04_07_tconstruct.json
@@ -30,7 +30,7 @@
       "text": "book.pastel.guidebook.mod_integration.tconstruct.page0.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.auto_harvesting",
       "condition": {
         "type": "modonomicon:advancement",
@@ -42,7 +42,7 @@
       "text": "book.pastel.guidebook.crystal_apothecary_harvesting"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.moving_budding_blocks",
       "condition": {
         "type": "modonomicon:advancement",

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/06_00_botania.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/06_00_botania.json
@@ -36,7 +36,7 @@
       "text": "book.pastel.guidebook.mod_integration.botania.page1.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.mod_integration.botania.page2.title",
       "item": {
         "item": "botania:magenta_mystical_petal"
@@ -61,7 +61,7 @@
       "recipe_id": "pastel:mod_integration/botania/pedestal/floral_fertilizer"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "botania:black_hole_talisman"
       },
@@ -89,7 +89,7 @@
       "recipe_id": "pastel:mod_integration/botania/spirit_instiller/overgrowth_seed"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.potion_reagent",
       "condition": {
         "type": "modonomicon:advancement",
@@ -101,7 +101,7 @@
       "text": "book.pastel.guidebook.mod_integration.botania.black_lotus_reagent.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.potion_reagent",
       "condition": {
         "type": "modonomicon:advancement",
@@ -113,7 +113,7 @@
       "text": "book.pastel.guidebook.mod_integration.botania.blacker_lotus_reagent.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.potion_reagent",
       "condition": {
         "type": "modonomicon:advancement",
@@ -125,7 +125,7 @@
       "text": "book.pastel.guidebook.mod_integration.botania.blackest_lotus_reagent.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.potion_reagent",
       "condition": {
         "type": "modonomicon:advancement",
@@ -137,7 +137,7 @@
       "text": "book.pastel.guidebook.mod_integration.botania.least_black_lotus_reagent.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.potion_reagent",
       "condition": {
         "type": "modonomicon:advancement",
@@ -149,7 +149,7 @@
       "text": "book.pastel.guidebook.mod_integration.botania.gaia_spirit_reagent.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.potion_reagent",
       "condition": {
         "type": "modonomicon:advancement",
@@ -161,7 +161,7 @@
       "text": "book.pastel.guidebook.mod_integration.botania.mana_powder_reagent.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.potion_reagent",
       "condition": {
         "type": "modonomicon:advancement",

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/06_04_more_geodes.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/06_04_more_geodes.json
@@ -30,7 +30,7 @@
       "title": "book.pastel.guidebook.mod_integration.more_geodes.name"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.auto_harvesting",
       "condition": {
         "type": "modonomicon:advancement",
@@ -42,7 +42,7 @@
       "text": "book.pastel.guidebook.crystal_apothecary_harvesting"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.moving_budding_blocks",
       "condition": {
         "type": "modonomicon:advancement",

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/08_00_byg.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/08_00_byg.json
@@ -30,7 +30,7 @@
       "title": "book.pastel.guidebook.mod_integration.byg.name"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.auto_harvesting",
       "condition": {
         "type": "modonomicon:advancement",
@@ -42,7 +42,7 @@
       "text": "book.pastel.guidebook.crystal_apothecary_harvesting"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.moving_budding_blocks",
       "condition": {
         "type": "modonomicon:advancement",

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/08_02_geode_plus.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/08_02_geode_plus.json
@@ -28,7 +28,7 @@
       "title": "book.pastel.guidebook.mod_integration.geode_plus.name"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.auto_harvesting",
       "condition": {
         "type": "modonomicon:advancement",
@@ -40,7 +40,7 @@
       "text": "book.pastel.guidebook.crystal_apothecary_harvesting"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.moving_budding_blocks",
       "condition": {
         "type": "modonomicon:advancement",

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/08_03_mythic_upgrades.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/08_03_mythic_upgrades.json
@@ -30,7 +30,7 @@
       "title": "book.pastel.guidebook.mod_integration.mythicupgrades.name"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.auto_harvesting",
       "condition": {
         "type": "modonomicon:advancement",
@@ -42,7 +42,7 @@
       "text": "book.pastel.guidebook.crystal_apothecary_harvesting"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.moving_budding_blocks",
       "condition": {
         "type": "modonomicon:advancement",

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/08_04_spelunkery.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/08_04_spelunkery.json
@@ -102,7 +102,7 @@
       "recipe_id": "pastel:mod_integration/spelunkery/potion_workshop_crafting/spring_water_bucket_crafting"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.mod_integration.spelunkery.black_materia_sluice.title",
       "condition": {
         "type": "modonomicon:advancement",

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/09_04_supplementaries.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/09_04_supplementaries.json
@@ -49,7 +49,7 @@
       "recipe_id": "pastel:mod_integration/supplementaries/enchanter/book_stasis"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.mod_integration.supplementaries.page3.title",
       "condition": {
         "type": "modonomicon:advancement",

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/09_05_malum.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/09_05_malum.json
@@ -50,7 +50,7 @@
       "recipe_id": "pastel:mod_integration/malum/pedestal/chorusless_ender_splice"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.mod_integration.malum.scythe_enchants.title",
       "item": {
         "item": "malum:crude_scythe",
@@ -115,7 +115,7 @@
       "recipe_id": "pastel:mod_integration/malum/potion_workshop_crafting/splash_of_gluttony"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.potion_reagent",
       "condition": {
         "type": "modonomicon:advancement",

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/09_06_dimdoors.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/mod_integration/09_06_dimdoors.json
@@ -30,7 +30,7 @@
       "title": "book.pastel.guidebook.mod_integration.dimdoors.name"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.mod_integration.dimdoors.altered_fabric_resonance.title",
       "condition": {
         "type": "modonomicon:advancement",

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/pastel_network/pastel_network.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/pastel_network/pastel_network.json
@@ -32,7 +32,7 @@
       "border": false
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "minecraft:name_tag",
         "components": {

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/pastel_network/pastel_network_coloring.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/pastel_network/pastel_network_coloring.json
@@ -24,7 +24,7 @@
       "text": "book.pastel.guidebook.pastel_network_coloring.page0.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "book.pastel.guidebook.pastel_network_coloring.page1.title",
       "item": {
         "item": "pastel:paintbrush",

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/pastel_network/upgrades/decorative.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/pastel_network/upgrades/decorative.json
@@ -21,7 +21,7 @@
       "text": "book.pastel.guidebook.pastel_upgrades.decorative.page0.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "item.pastel.shimmerstone_gem",
       "item": {
         "item": "pastel:shimmerstone_gem"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/pastel_network/upgrades/redstone.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/pastel_network/upgrades/redstone.json
@@ -21,7 +21,7 @@
   "y": 1,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:pure_redstone"
       },
@@ -32,7 +32,7 @@
       }
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:pure_coal"
       },
@@ -43,7 +43,7 @@
       }
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:pure_echo"
       },
@@ -54,7 +54,7 @@
       }
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:pure_lapis"
       },
@@ -65,7 +65,7 @@
       }
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:pure_quartz"
       },
@@ -76,7 +76,7 @@
       }
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:pure_glowstone"
       },

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/pastel_network/upgrades/transfer.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/pastel_network/upgrades/transfer.json
@@ -16,7 +16,7 @@
   "y": -1,
   "pages": [
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "item.pastel.raw_azurite",
       "item": {
         "item": "pastel:raw_azurite"
@@ -24,7 +24,7 @@
       "text": "book.pastel.guidebook.pastel_upgrades.transfer.raw_azurite.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "item.pastel.pure_azurite",
       "item": {
         "item": "pastel:pure_azurite"
@@ -36,7 +36,7 @@
       }
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "item.pastel.raw_malachite",
       "item": {
         "item": "pastel:raw_malachite"
@@ -48,7 +48,7 @@
       }
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "item.pastel.pure_malachite",
       "item": {
         "item": "pastel:pure_malachite"
@@ -60,7 +60,7 @@
       }
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "item.pastel.raw_bloodstone",
       "item": {
         "item": "pastel:raw_bloodstone"
@@ -72,7 +72,7 @@
       }
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "item.pastel.pure_bloodstone",
       "item": {
         "item": "pastel:pure_bloodstone"
@@ -84,7 +84,7 @@
       }
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "title": "item.pastel.resonance_shard",
       "item": {
         "item": "pastel:resonance_shard"

--- a/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/pastel_network/upgrades/upgrades.json
+++ b/src/main/resources/data/pastel/modonomicon/books/guidebook/entries/pastel_network/upgrades/upgrades.json
@@ -21,7 +21,7 @@
       "text": "book.pastel.guidebook.pastel_upgrades.about.text"
     },
     {
-      "type": "modonomicon:spotlight",
+      "type": "pastel:cloaked_spotlight",
       "item": {
         "item": "pastel:connection_node"
       },


### PR DESCRIPTION
this isn't an ideal fix by any means, but it doesn't particularly matter if in 2.0 we are gonna nuke modnomicon anyway.

this makes it always recheck the hover name of an item for the spotlight page if there was no explicit title specified.

Does this by making an entirely new page type that overrides two methods in spotlight page to track whether a title was unspecified and to return the items hovername every time if it was indeed unspecified. This means that databank's mixins will work now since it correctly tracks the state of cloaking