### PR TITLE
Add Azure Spires biome to `#c:is_underground`

### DIFF
--- a/src/data/java/earth/terrarium/pastel/data/PastelBiomeTagsProvider.java
+++ b/src/data/java/earth/terrarium/pastel/data/PastelBiomeTagsProvider.java
@@ -1,0 +1,30 @@
+package earth.terrarium.pastel.data;
+
+import earth.terrarium.pastel.PastelCommon;
+import earth.terrarium.pastel.registries.PastelBiomes;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.data.PackOutput;
+import net.minecraft.data.tags.TagsProvider;
+import net.minecraft.world.level.biome.Biome;
+import net.neoforged.neoforge.common.Tags;
+import net.neoforged.neoforge.common.data.ExistingFileHelper;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.concurrent.CompletableFuture;
+
+public class PastelBiomeTagsProvider extends TagsProvider<Biome> {
+    protected PastelBiomeTagsProvider(
+        PackOutput output,
+        CompletableFuture<HolderLookup.Provider> lookupProvider,
+        @Nullable ExistingFileHelper existingFileHelper
+    ) {
+        super(output, Registries.BIOME, lookupProvider, PastelCommon.MOD_ID, existingFileHelper);
+    }
+
+    @Override
+    protected void addTags(HolderLookup.Provider lookupProvider) {
+        tag(Tags.Biomes.IS_UNDERGROUND)
+            .add(PastelBiomes.AZURE_SPIRES);
+    }
+}

--- a/src/data/java/earth/terrarium/pastel/data/PastelDataGenerator.java
+++ b/src/data/java/earth/terrarium/pastel/data/PastelDataGenerator.java
@@ -60,5 +60,6 @@ public class PastelDataGenerator {
                     lookupProvider
                 )
             );
+        event.addProvider(new PastelBiomeTagsProvider(packOutput, lookupProvider, existingFileHelper));
     }
 }

--- a/src/main/generated/data/c/tags/worldgen/biome/is_underground.json
+++ b/src/main/generated/data/c/tags/worldgen/biome/is_underground.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "pastel:azure_spires"
+  ]
+}


### PR DESCRIPTION
Fixes compatibility with No Man's Land's "cave biomes"

May want to consider adding it to other biome tags for MAXIMUM COMPATIBILITY...